### PR TITLE
liblab SDK update v0.9.0-alpha.4

### DIFF
--- a/.manifest.json
+++ b/.manifest.json
@@ -1,6 +1,6 @@
 {
   "liblabVersion": "2.5.1",
-  "date": "2024-10-05T04:00:40.746Z",
+  "date": "2024-10-05T04:27:11.524Z",
   "config": {
     "apiId": 1126,
     "sdkName": "salad-cloud-imds-sdk",
@@ -156,7 +156,7 @@
     },
     "multiTenant": true,
     "hooksLocation": {
-      "bucketKey": "7538/hooks.zip",
+      "bucketKey": "7539/hooks.zip",
       "bucketName": "prod-liblab-api-stack-hooks"
     },
     "includeWatermark": false,


### PR DESCRIPTION
## Automatically generated PR with SDK updates by liblab.

- API version: **v1.0.0**
- SDK version: **v0.9.0-alpha.4**